### PR TITLE
NerdPack: PHP7 compatibility (unRAID 6.3.0-rc2+)

### DIFF
--- a/source/NerdPack/usr/local/emhttp/plugins/NerdPack/include/PackageQuery.php
+++ b/source/NerdPack/usr/local/emhttp/plugins/NerdPack/include/PackageQuery.php
@@ -47,7 +47,7 @@ foreach ($pkgs_github_array as $pkg_github) {
         $pkg_set = "no";
         foreach ($pkg_cfg as $pkg_key => $pkg_line) {
             if (preg_match('/^'.$pkg_name.'.*/',$pkg_key)){
-                if(sizeof(array_diff(split('-', $pkg_key), split('-', $pkg_name))) < 2 ){
+                if(sizeof(array_diff(explode('-', $pkg_key), explode('-', $pkg_name))) < 2 ){
                     $pkg_set = $pkg_line;
                     break;
                 }


### PR DESCRIPTION
The PHP function `split()` (alias of explode()) was deprecated for a while and was finally removed in php7.  Replaced them with explode().  As of unRAID 6.3.0-rc2, PHP was upgraded to version 7.0.x.
